### PR TITLE
Fix transfort.rs: correct multiplicative inverse.

### DIFF
--- a/src/transform.rs
+++ b/src/transform.rs
@@ -94,8 +94,8 @@ pub struct ModularDivideByThree<R>(pub R);
 
 impl<R: Random> Random for ModularDivideByThree<R> {
     fn get_random(&mut self) -> u64 {
-        // 12297829382473035776 is the multiplicative inverse of 3 in the ring Z/2^64Z.
-        self.0.get_random().wrapping_mul(12297829382473035776)
+        // 12297829382473034411 is the multiplicative inverse of 3 in the ring Z/2^64Z.
+        self.0.get_random().wrapping_mul(12297829382473034411)
     }
 }
 


### PR DESCRIPTION
The multiplicative inverse of 3 in Z/2^64Z is 12297829382473034411.

It can be shown quickly:
ϕ(2^64) = 9223372036854775808 (Euler's totient function)
3^(ϕ(2^64) - 1) ≡ 12297829382473034411 (mod 2^64).

Obviously, the same result can be found with the extended Euclidean algorithm.
